### PR TITLE
Adjusted default scaling factors for desktop and browser to 125%/130%

### DIFF
--- a/src/com.endlessm.CompositeMode.gschema.xml
+++ b/src/com.endlessm.CompositeMode.gschema.xml
@@ -32,12 +32,12 @@
   <schema id="com.endlessm.CompositeMode.composite" path="/com/endlessm/CompositeMode/composite/">
     <key name="text-scaling-factor" type="d">
       <range min="1.0" max="2.0"/>
-      <default>1.1</default>
+      <default>1.25</default>
       <summary>Default value for com.endlessm.CompositeMode.text-scaling-factor in Composite mode</summary>
     </key>
     <key name="browser-scaling-factor" type="d">
       <range min="1.0" max="2.0"/>
-      <default>1.2</default>
+      <default>1.05</default>
       <summary>Default value for com.endlessm.CompositeMode.browser-scaling-factor in Composite mode</summary>
     </key>
   </schema>


### PR DESCRIPTION
We want to bump the default for the desktop from the current 110% up
to 125%, but keep the browser at 130%, so we adjust both factors to
get that effect (for browser, this will be 1.25 \* 1.05 = 1.3125).

Technically, we could use a factor of 1.0 for the browser since the
current code in chromium rounds first the value and ignore it if is
less than 1.3 (and 1.25 would round up to 1.3). But the current status
upstream is that the filtering will be now done before rounding, so
we better use 1.05 instead, so that we are prepared for the future.

See https://codereview.chromium.org/1581883003 for more details on this.

[endlessm/eos-shell#6308]
