### PR TITLE
Update description for browser-scaling-factor setting

### DIFF
--- a/src/com.endlessm.CompositeMode.gschema.xml
+++ b/src/com.endlessm.CompositeMode.gschema.xml
@@ -13,7 +13,7 @@
       <default>1.0</default>
       <summary>Accumulative text scaling factor for the browser only</summary>
       <description>
-        Extra scaling factor only used by the browser, to be applied on top of text-scaling-factor. Note: chromium won't do any scaling if the end value is less than 1.3 (crbug.com/484400).
+        Extra scaling factor only used by the browser, to be applied on top of text-scaling-factor. Note: chromium won't do any scaling if the end value is less than 1.2 (crbug.com/484400).
       </description>
     </key>
   </schema>


### PR DESCRIPTION
As of Chromium 57, this threshold has been reduced from 1.3 to 1.2.

@mariospr @ltilve this is simple enough that I decided not to bother with a Phabricator issue for it.